### PR TITLE
Fix mvn build compile protobuf error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,15 @@
 			<version>1.48</version>
 		</dependency>
 
+		<!-- Fix compile symbol not found exception, please make sure the version of
+		     protoc.exe is the same as protobuf-java
+		-->
+		<dependency>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java</artifactId>
+			<version>3.5.0</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.jpmml</groupId>
 			<artifactId>jpmml-converter</artifactId>

--- a/src/main/java/org/jpmml/tensorflow/SavedModel.java
+++ b/src/main/java/org/jpmml/tensorflow/SavedModel.java
@@ -133,7 +133,7 @@ public class SavedModel implements AutoCloseable {
 
 		Runner runner = (session.runner()).fetch(name);
 
-		List<Tensor> tensors = runner.run();
+		List<Tensor<?>> tensors = runner.run();
 
 		return Iterables.getOnlyElement(tensors);
 	}


### PR DESCRIPTION
## What changes were proposed in this pull request?
**1. Fix mvn build error**
build the master branch, I got many errors as follows:
jpmml-tensorflow/target/generated-sources/protobuf/java/org/tensorflow/framework/TensorProto.java:[63,18] Can't Find Symbol

**2. Fix a compile error in jpmml-tensorflow/src/main/java/org/jpmml/tensorflow/SavedModel.java**
The error is 
/Users/lgrcyanny/Codecookies/machine-learning-workspace/pmml-wp/jpmml-tensorflow/src/main/java/org/jpmml/tensorflow/SavedModel.java:[136,50] incompatiable with: java.util.List<org.tensorflow.Tensor<?>> can't transformed to java.util.List<org.tensorflow.Tensor>

The reason is tensorflow latest API is 1.4

## How was this patch tested?
build on my local MAC machine and success
+ protoc version is 3.5.0
+ jdk 1.8
+ tensorlfow 1.4
